### PR TITLE
feat: man-1634 allow users to override sdkMetada options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ const sdk = new AmplienceImageStudio();
 
 _Creating a global instance of `AmplienceImageStudio` is advised against, and a new one should be created for each interaction due to shared promise management you may get expected results if you make asynchronous interactions with the same instance._
 
-## ImageStudioOptions
+## AmplienceImageStudioOptions
 When creating an `AmplienceImageStudio` instance, the constructor takes an `AmplienceImageStudioOptions` object. This defines several options for customizing the behaviour of the studio:
 
 | Key | Description | Default | Optional |

--- a/README.md
+++ b/README.md
@@ -33,6 +33,41 @@ const sdk = new AmplienceImageStudio();
 
 _Creating a global instance of `AmplienceImageStudio` is advised against, and a new one should be created for each interaction due to shared promise management you may get expected results if you make asynchronous interactions with the same instance._
 
+## ImageStudioOptions
+When creating an `AmplienceImageStudio` instance, the constructor takes an `AmplienceImageStudioOptions` object. This defines several options for customizing the behaviour of the studio:
+
+| Key | Description | Default | Optional |
+|:----------|:-------------|:-:|:-:|
+| domain |  base domain for your image-studio deployment | - | No |
+| sdkMetadataOverride |    object containing behavioural overrides for image-studio [SDKMetadata](#sdkmetadata)   | {} | Yes |
+| windowTarget | window.open() `target` override, please see [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/open) | '_blank' | Yes |
+| windowFeatures | window.open() `windowFeatures` override, please see [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/open) | '' | Yes |
+
+## SDKMetadata
+
+This SDK controls certain behaviours within image-studio through optional enablement flags.
+
+_Failing to submit an option to image-studio will not result in any bad behaviour. Image-Studio determines and controls the default behaviour of every option, however the structure and options available are controlled by this SDK._
+
+| Option | Description | Default |
+|:----------|:-|:-:|
+| `allowImageSave` | allows content to be saved back to the SDK | `false` |
+| `allowLogout` | allows users to logout | `true` |
+| `allowCreate` | allows users to create new content | `true` |
+
+## Image Studio Actions
+
+Each action contains a default set of behavioural options:
+
+_Note that not every option is supplied by default._
+
+| Action | Options |
+|:----------|:-|
+| `editImages` | allowImageSave: true<br>allowLogout: false<br>allowCreate: false |
+| `launch` | allowImageSave: false<br>allowLogout: true<br>allowCreate: true |
+
+The user can override the default action behaviours by adding the relevant options to the `sdkMetadataOverride` member foun within `AmplienceImageStudioOptions`
+
 ### Edit Images
 
 Image Studio expects an array of images for editing, once the user has editied the images and clicked 'Save Image', the resultant image will be returned within the response object and the Image Studio window will be closed.
@@ -40,7 +75,9 @@ Image Studio expects an array of images for editing, once the user has editied t
 _Note: Image Studio currently only uses the first image you submit via this call_
 
 ```js
-const sdk = new AmplienceImageStudio();
+const sdk = new AmplienceImageStudio({
+    domain: IMAGE_STUDIO_DOMAIN,
+});
 const response = await sdk.editImages([{
     url: 'https://url-to-your-image',
     name: 'image-name',
@@ -63,7 +100,9 @@ if(response.reason == ImageStudioReason.IMAGE) {
 Launches an Image Studio session standalone, which allows the user to select their own image for editing. Users are _not_ able to save content back to their application and will only be able to download their creations locally.
 
 ```js
-const sdk = new AmplienceImageStudio();
+const sdk = new AmplienceImageStudio({
+    domain: IMAGE_STUDIO_DOMAIN,
+});
 const response = await sdk.launch();
 
 if(response.reason == ImageStudioReason.CLOSED) {

--- a/src/AmplienceImageStudio.ts
+++ b/src/AmplienceImageStudio.ts
@@ -94,7 +94,7 @@ class AmplienceImageStudioInstance<T> {
 
     const imageStudioUrl =
       route && route.trim().length > 0
-        ? `${domain}/image-studio/${route}`
+        ? `${domain}/image-studio/${route.trim()}`
         : `${domain}/image-studio`;
 
     const newWindow = window.open(imageStudioUrl, windowTarget, windowFeatures);

--- a/src/stories/AmplienceImageStudio.stories.ts
+++ b/src/stories/AmplienceImageStudio.stories.ts
@@ -6,7 +6,8 @@ import {
 } from '../AmplienceImageStudio';
 import { ImageStudioReason, SDKImage } from '../types';
 
-const IMAGE_STUDIO_URL = 'https://app.amplience.net/image-studio/';
+const IMAGE_STUDIO_DOMAIN = 'https://app.amplience.net';
+// const IMAGE_STUDIO_DOMAIN = 'http://localhost:5173';
 
 interface AmplienceImageStudioProps {
   imageUrl: string;
@@ -36,7 +37,8 @@ export const TryMe: Story = {
     imageName: 'elephant-wild-t',
     mimeType: 'image/jpeg',
     options: {
-      baseUrl: IMAGE_STUDIO_URL,
+      domain: IMAGE_STUDIO_DOMAIN,
+      sdkMetadataOverride: {},
     },
   },
   render: (args) => {
@@ -118,7 +120,7 @@ export const EditImages_CloseWithoutSendingImage: Story = {
       },
     ];
     const imageStudio = new AmplienceImageStudio({
-      baseUrl: IMAGE_STUDIO_URL,
+      domain: IMAGE_STUDIO_DOMAIN,
     });
     const response = await imageStudio.editImages(inputImages);
 
@@ -136,7 +138,7 @@ export const EditImages_SaveWhitelisedImageToContentForm: Story = {
       },
     ];
     const imageStudio = new AmplienceImageStudio({
-      baseUrl: IMAGE_STUDIO_URL,
+      domain: IMAGE_STUDIO_DOMAIN,
     });
     const response = await imageStudio.editImages(inputImages);
 
@@ -160,7 +162,7 @@ export const EditImages_SaveNonWhitelisedImageToContentForm: Story = {
       },
     ];
     const imageStudio = new AmplienceImageStudio({
-      baseUrl: IMAGE_STUDIO_URL,
+      domain: IMAGE_STUDIO_DOMAIN,
     });
     const response = await imageStudio.editImages(inputImages);
 
@@ -177,7 +179,7 @@ export const EditImages_SaveNonWhitelisedImageToContentForm: Story = {
 export const LaunchStandalone: Story = {
   play: async () => {
     const imageStudio = new AmplienceImageStudio({
-      baseUrl: IMAGE_STUDIO_URL,
+      domain: IMAGE_STUDIO_DOMAIN,
     });
     const response = await imageStudio.launch();
     expect(response?.reason).toBe(ImageStudioReason.CLOSED);

--- a/src/types/Message.ts
+++ b/src/types/Message.ts
@@ -2,10 +2,13 @@ import { SDKImage } from './ImageStudio';
 
 /**
  * Metadata object that is sent to ImageStudio on successful connection
+ * Contains configurable image-studio behaviour.
+ * All behaviours are optional to reduce the need for breaking changes in future.
  */
 export interface SDKMetadata {
-  allowImageSave: boolean;
-  allowLogout: boolean;
+  allowImageSave?: boolean;
+  allowLogout?: boolean;
+  allowCreate?: boolean;
 }
 
 /**


### PR DESCRIPTION
- man-1634 allow users to override sdkMetada options
- man-1641 adds allowCreate prop to SDKMetadata
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.3.0--canary.12.e3bdaed.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @amplience/image-studio-sdk@0.3.0--canary.12.e3bdaed.0
  # or 
  yarn add @amplience/image-studio-sdk@0.3.0--canary.12.e3bdaed.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
