### PR TITLE
build: adds in specific token for contents write access

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,14 +6,13 @@ jobs:
   release:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
-    permissions:
-      contents: write
-      issues: read
-      packages: write
-      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
+        with: 
+          # This token is scoped to public repo's and only has write contents_access
+          # It is specifically required to allow commits back to this repository as part of `auto shipit`
+          token: ${{ secrets.GH_PUBLIC_REPO_CONTENTS_ACCESS }}
 
       - name: Prepare repository
         # Fetch full git history and tags

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amplience/image-studio-sdk",
-  "version": "0.5.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amplience/image-studio-sdk",
-      "version": "0.5.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@auto-it/conventional-commits": "^11.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplience/image-studio-sdk",
-  "version": "0.5.0",
+  "version": "0.2.0",
   "type": "module",
   "license": "Apache-2.0",
   "description": "Image Studio SDK",


### PR DESCRIPTION
Build should not need the permissions block in the config yaml

We have created a new fine grained PAT on amp-automation, that is scoped ONLY to this repo (and potentially other public repos in future). The PAT has been exposed to this repo through `secrets.GH_PUBLIC_REPO_CONTENTS_ACCESS`

https://intuit.github.io/auto/docs/build-platforms/github-actions#running-with-branch-protection