### PR TITLE
fix: whitespace test to trigger PR and build

### DIFF
--- a/src/stories/AmplienceImageStudio.stories.ts
+++ b/src/stories/AmplienceImageStudio.stories.ts
@@ -136,6 +136,7 @@ export const EditImages_SaveWhitelisedImageToContentForm: Story = {
         mimeType: 'image/jpeg',
       },
     ];
+
     const imageStudio = new AmplienceImageStudio({
       baseUrl: IMAGE_STUDIO_URL,
     });


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.5.4--canary.18.5ba910d.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @amplience/image-studio-sdk@0.5.4--canary.18.5ba910d.0
  # or 
  yarn add @amplience/image-studio-sdk@0.5.4--canary.18.5ba910d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
