### PR TITLE
feat: MAN-1684 pass org id through sdk when launching from dc

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,15 +117,15 @@ Along with the above options, some properties can be set following the builder p
 
 ```js
 const sdk = new AmplienceImageStudio({domain: IMAGE_STUDIO_DOMAIN})
-    .withOrgId('EXAMPLE_ID');
+    .withDecodedOrgId('Org_Exampleid');
 ```
 
 Here are the options that use this approach:
 
 | Option | Description | Default |
 |:----------|:-|:-:|
-| `.withEncodedOrgId('EXAMPLE_ID')` | Set the user organisation by providing its Base64 encoded ID (used for entitlements and credit consumption)| `` |
-| `.withDecodedOrgId('EXAMPLE_ID')` | Set user organisation by providing its decoded ID (used for entitlements and credit consumption)| `` |
+| `.withEncodedOrgId('Org_Exampleid')` | Set the user organisation by providing its Base64 encoded ID (used for entitlements and credit consumption)| `` |
+| `.withDecodedOrgId('Org_Exampleid')` | Set user organisation by providing its decoded ID (used for entitlements and credit consumption)| `` |
 
 
 ## Releases

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ _Failing to submit an option to image-studio will not result in any bad behaviou
 | `allowImageSave` | allows content to be saved back to the SDK | `false` |
 | `allowLogout` | allows users to logout | `true` |
 | `allowCreate` | allows users to create new content | `true` |
+|`orgId`| user organisation ID (used for entitlements and credit consumption) | unset
 
 ## Image Studio Actions
 
@@ -81,7 +82,7 @@ const sdk = new AmplienceImageStudio({
 const response = await sdk.editImages([{
     url: 'https://url-to-your-image',
     name: 'image-name',
-    mimeType: 'image/jpeg', 
+    mimeType: 'image/jpeg',
 }]);
 
 if(response.reason == ImageStudioReason.IMAGE) {
@@ -90,7 +91,7 @@ if(response.reason == ImageStudioReason.IMAGE) {
     // {
     //     url: 'https://url-to-your-updated-image',
     //     name: 'updated-image-name',
-    //     mimeType: 'image/jpeg', 
+    //     mimeType: 'image/jpeg',
     // }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -32,44 +32,20 @@ const sdk = new AmplienceImageStudio();
 ```
 
 _Creating a global instance of `AmplienceImageStudio` is advised against, and a new one should be created for each interaction due to shared promise management you may get expected results if you make asynchronous interactions with the same instance._
+## AmplienceImageStudio - Quick Start
 
-## AmplienceImageStudioOptions
-When creating an `AmplienceImageStudio` instance, the constructor takes an `AmplienceImageStudioOptions` object. This defines several options for customizing the behaviour of the studio:
-
-| Key | Description | Default | Optional |
-|:----------|:-------------|:-:|:-:|
-| domain |  base domain for your image-studio deployment | - | No |
-| sdkMetadataOverride |    object containing behavioural overrides for image-studio [SDKMetadata](#sdkmetadata)   | {} | Yes |
-| windowTarget | window.open() `target` override, please see [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/open) | '_blank' | Yes |
-| windowFeatures | window.open() `windowFeatures` override, please see [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/open) | '' | Yes |
-
-## SDKMetadata
-
-This SDK controls certain behaviours within image-studio through optional enablement flags.
-
-_Failing to submit an option to image-studio will not result in any bad behaviour. Image-Studio determines and controls the default behaviour of every option, however the structure and options available are controlled by this SDK._
-
-| Option | Description | Default |
-|:----------|:-|:-:|
-| `allowImageSave` | allows content to be saved back to the SDK | `false` |
-| `allowLogout` | allows users to logout | `true` |
-| `allowCreate` | allows users to create new content | `true` |
-|`orgId`| user organisation ID (used for entitlements and credit consumption) | unset
-
-## Image Studio Actions
+### Image Studio Actions
 
 Each action contains a default set of behavioural options:
-
-_Note that not every option is supplied by default._
 
 | Action | Options |
 |:----------|:-|
 | `editImages` | allowImageSave: true<br>allowLogout: false<br>allowCreate: false |
 | `launch` | allowImageSave: false<br>allowLogout: true<br>allowCreate: true |
 
-The user can override the default action behaviours by adding the relevant options to the `sdkMetadataOverride` member foun within `AmplienceImageStudioOptions`
+The user can override the default action behaviours by adding the relevant options to the [`sdkMetadataOverride`](#sdkmetadata) member found within [`AmplienceImageStudioOptions`](#amplienceimagestudiooptions)
 
-### Edit Images
+#### Edit Images
 
 Image Studio expects an array of images for editing, once the user has editied the images and clicked 'Save Image', the resultant image will be returned within the response object and the Image Studio window will be closed.
 
@@ -96,7 +72,7 @@ if(response.reason == ImageStudioReason.IMAGE) {
 }
 ```
 
-### Launch
+#### Launch
 
 Launches an Image Studio session standalone, which allows the user to select their own image for editing. Users are _not_ able to save content back to their application and will only be able to download their creations locally.
 
@@ -110,6 +86,46 @@ if(response.reason == ImageStudioReason.CLOSED) {
     console.log("Success");
 }
 ```
+
+
+## AmplienceImageStudioOptions
+
+When creating an `AmplienceImageStudio` instance, the constructor takes an `AmplienceImageStudioOptions` object. This defines several options for customizing the behaviour of the studio:
+
+| Key | Description | Default | Optional |
+|:----------|:-------------|:-:|:-:|
+| domain |  base domain for your image-studio deployment | - | No |
+| sdkMetadataOverride |    object containing behavioural overrides for image-studio [SDKMetadata](#sdkmetadata)   | {} | Yes |
+| windowTarget | window.open() `target` override, please see [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/open) | '_blank' | Yes |
+| windowFeatures | window.open() `windowFeatures` override, please see [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/open) | '' | Yes |
+
+### SDKMetadata
+
+This SDK controls certain behaviours within image-studio through optional enablement flags.
+
+_Failing to submit an option to image-studio will not result in any bad behaviour. Image-Studio determines and controls the default behaviour of every option, however the structure and options available are controlled by this SDK._
+
+| Option | Description | Default |
+|:----------|:-|:-:|
+| `allowImageSave` | allows content to be saved back to the SDK | `false` |
+| `allowLogout` | allows users to logout | `true` |
+| `allowCreate` | allows users to create new content | `true` |
+|`orgId`*| user organisation ID (used for entitlements and credit consumption) | ''
+
+Along with the above options, some properties can be set following the builder pattern:
+
+
+```js
+const sdk = new AmplienceImageStudio({domain: IMAGE_STUDIO_DOMAIN})
+    .withOrgId('EXAMPLE_ID');
+```
+
+Here are the options that use this approach:
+
+| Option | Description | Default |
+|:----------|:-|:-:|
+| `.withOrgId('EXAMPLE_ID')` | user organisation ID (used for entitlements and credit consumption)| `` |
+
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ Here are the options that use this approach:
 
 | Option | Description | Default |
 |:----------|:-|:-:|
-| `.withEncodedOrgId('Org_Exampleid')` | Set the user organisation by providing its Base64 encoded ID (used for entitlements and credit consumption)| `` |
-| `.withDecodedOrgId('Org_Exampleid')` | Set user organisation by providing its decoded ID (used for entitlements and credit consumption)| `` |
+| `.withEncodedOrgId('b3JnYW5pemF0aW9u')` | - Set the user organisation to be used for entitlements and credit consumption. <br> - must provide Base64 encoded ID i.e. GQL data| `` |
+| `.withDecodedOrgId('Org_Exampleid')` |  - Set the user organisation to be used for entitlements and credit consumption. <br> - must provide plain text ID i.e. dc-extensions-sdk data| `` |
 
 
 ## Releases

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ Here are the options that use this approach:
 
 | Option | Description | Default |
 |:----------|:-|:-:|
-| `.withOrgId('EXAMPLE_ID')` | user organisation ID (used for entitlements and credit consumption)| `` |
+| `.withEncodedOrgId('EXAMPLE_ID')` | Set the user organisation by providing its Base64 encoded ID (used for entitlements and credit consumption)| `` |
+| `.withDecodedOrgId('EXAMPLE_ID')` | Set user organisation by providing its decoded ID (used for entitlements and credit consumption)| `` |
 
 
 ## Releases

--- a/src/AmplienceImageStudio.ts
+++ b/src/AmplienceImageStudio.ts
@@ -23,7 +23,22 @@ export class AmplienceImageStudio {
 
   constructor(protected options: AmplienceImageStudioOptions) {}
 
-  public withOrgId(orgId: string): AmplienceImageStudio {
+  /**
+   * Encodes the orgId and sets it in sdkMetadata to be passed to the studio
+   * @param orgId - must be decoded plain text string
+   * @returns
+   */
+  public withDecodedOrgId(orgId: string): AmplienceImageStudio {
+    this.defaultMetadata.orgId = btoa(`Organization:${orgId}`);
+    return this;
+  }
+
+  /**
+   * Sets the sdkMetadata orgId to be passed to the studio
+   * @param orgId - must be Base64 encoded string
+   * @returns
+   */
+  public withEncodedOrgId(orgId: string): AmplienceImageStudio {
     this.defaultMetadata.orgId = orgId;
     return this;
   }

--- a/src/AmplienceImageStudio.ts
+++ b/src/AmplienceImageStudio.ts
@@ -19,7 +19,14 @@ export type AmplienceImageStudioOptions = {
 };
 
 export class AmplienceImageStudio {
+  private defaultMetadata: SDKMetadata = {};
+
   constructor(protected options: AmplienceImageStudioOptions) {}
+
+  public withOrgId(orgId: string): AmplienceImageStudio {
+    this.defaultMetadata.orgId = orgId;
+    return this;
+  }
 
   /**
    * launches image studio to edit the images
@@ -29,6 +36,7 @@ export class AmplienceImageStudio {
   public editImages(inputImages: SDKImage[]): Promise<ImageStudioResponse> {
     const instance = this.createInstance<ImageStudioResponse>();
     return instance.launch(
+      this.defaultMetadata,
       {
         allowImageSave: true,
         allowLogout: false,
@@ -46,6 +54,7 @@ export class AmplienceImageStudio {
   public launch(): Promise<ImageStudioResponse> {
     const instance = this.createInstance<ImageStudioResponse>();
     return instance.launch(
+      this.defaultMetadata,
       {
         allowImageSave: false,
         allowLogout: true,
@@ -82,6 +91,7 @@ class AmplienceImageStudioInstance<T> {
 
   launch(
     defaultSdkMetadata: SDKMetadata,
+    actionSdkMetadata: SDKMetadata,
     inputImages: SDKImage[],
     route: string = '',
   ): Promise<T> {
@@ -104,8 +114,12 @@ class AmplienceImageStudioInstance<T> {
       // If the user specified sdkMetadataOverride in their AmplienceImageStudioOptions, merge with the defaults and prioritze the overridden options.
       // SDKMetadata contains optional parameters, so both arrays might not contain everything. ImageStudio should cope with partial options being sent.
       const sdkMetadata: SDKMetadata = this.options?.sdkMetadataOverride
-        ? { ...defaultSdkMetadata, ...this.options.sdkMetadataOverride }
-        : defaultSdkMetadata;
+        ? {
+            ...defaultSdkMetadata,
+            ...actionSdkMetadata,
+            ...this.options.sdkMetadataOverride,
+          }
+        : { ...defaultSdkMetadata, ...actionSdkMetadata };
 
       this.launchProps = {
         imageStudioUrl,

--- a/src/stories/AmplienceImageStudio.stories.ts
+++ b/src/stories/AmplienceImageStudio.stories.ts
@@ -40,6 +40,7 @@ export const TryMe: Story = {
       domain: IMAGE_STUDIO_DOMAIN,
       sdkMetadataOverride: {},
     },
+    orgId: '',
   },
   render: (args) => {
     const wrapper = document.createElement('div');
@@ -48,6 +49,9 @@ export const TryMe: Story = {
     wrapper.style.alignItems = 'center';
 
     const imageStudio = new AmplienceImageStudio(args.options);
+    if (args.orgId) {
+      imageStudio.withOrgId(args.orgId);
+    }
     const launch = document.createElement('button');
     launch.innerText = 'Launch';
     launch.onclick = async () => {

--- a/src/stories/AmplienceImageStudio.stories.ts
+++ b/src/stories/AmplienceImageStudio.stories.ts
@@ -51,7 +51,7 @@ export const TryMe: Story = {
 
     const imageStudio = new AmplienceImageStudio(args.options);
     if (args.encodedOrgId) {
-      imageStudio.withEncodedOrgId(args.orgId);
+      imageStudio.withEncodedOrgId(args.encodedOrgId);
     }
     if (args.decodedOrgId) {
       imageStudio.withDecodedOrgId(args.decodedOrgId);

--- a/src/stories/AmplienceImageStudio.stories.ts
+++ b/src/stories/AmplienceImageStudio.stories.ts
@@ -40,7 +40,8 @@ export const TryMe: Story = {
       domain: IMAGE_STUDIO_DOMAIN,
       sdkMetadataOverride: {},
     },
-    orgId: '',
+    encodedOrgId: '',
+    decodedOrgId: '',
   },
   render: (args) => {
     const wrapper = document.createElement('div');
@@ -49,8 +50,11 @@ export const TryMe: Story = {
     wrapper.style.alignItems = 'center';
 
     const imageStudio = new AmplienceImageStudio(args.options);
-    if (args.orgId) {
-      imageStudio.withOrgId(args.orgId);
+    if (args.encodedOrgId) {
+      imageStudio.withEncodedOrgId(args.orgId);
+    }
+    if (args.decodedOrgId) {
+      imageStudio.withDecodedOrgId(args.decodedOrgId);
     }
     const launch = document.createElement('button');
     launch.innerText = 'Launch';

--- a/src/types/Message.ts
+++ b/src/types/Message.ts
@@ -9,6 +9,7 @@ export interface SDKMetadata {
   allowImageSave?: boolean;
   allowLogout?: boolean;
   allowCreate?: boolean;
+  orgId?: string;
 }
 
 /**


### PR DESCRIPTION
### What are the changes? 📝
Adds new methods to set the orgId:

`withDecodedOrgId()` - supports providing orgId as decoded string.
`withEncodedOrgId()` - supports providing orgId as Base64 encoded string.

#### example
`const sdk = new AmplienceImageStudio({domain: IMAGE_STUDIO_DOMAIN})`
                `.withDecodedOrgId('Org_exampleid');`


### Reason for change
A user may be a member of multiple organisations. Therefore, when Image Studio is launched from DC, it should be possible to work out the orgId in DC and pass it through the SDK, to be used in Image Studio for entitlement checks and credit consumption.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.3.1--canary.29.fa77c75.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @amplience/image-studio-sdk@0.3.1--canary.29.fa77c75.0
  # or 
  yarn add @amplience/image-studio-sdk@0.3.1--canary.29.fa77c75.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
