### PR TITLE
fix: man-1780 support for async Event Callbacks

### DIFF
--- a/src/stories/AmplienceImageStudio.stories.ts
+++ b/src/stories/AmplienceImageStudio.stories.ts
@@ -35,6 +35,10 @@ const meta: Meta<AmplienceImageStudioProps> = {
 export default meta;
 type Story = StoryObj;
 
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export const TryMe: Story = {
   args: {
     imageUrl:
@@ -70,7 +74,7 @@ export const TryMe: Story = {
 
       const imageStudio = new AmplienceImageStudio(
         args.options,
-      ).withEventListener(ImageStudioEventType.ImageSave, (data) => {
+      ).withEventListener(ImageStudioEventType.ImageSave, async (data) => {
         const imageData = data as ImageSaveEventData;
         nameText.nodeValue = imageData?.image.name;
         urlText.nodeValue = imageData?.image.url;
@@ -120,7 +124,7 @@ export const CloseImageStudioWithoutSavingImage: Story = {
 
     const imageStudio = new AmplienceImageStudio({
       domain: IMAGE_STUDIO_DOMAIN,
-    }).withEventListener(ImageStudioEventType.ImageSave, () => {
+    }).withEventListener(ImageStudioEventType.ImageSave, async () => {
       expect(true).toBeFalsy(); //cause a failure if the user presses save
       return SDKEventType.Fail;
     });
@@ -128,7 +132,7 @@ export const CloseImageStudioWithoutSavingImage: Story = {
   },
 };
 
-export const SaveWhitelisedImage_ShouldReportSuccess: Story = {
+export const SaveWhitelisedImage_ShouldReportSuccessAfter2Second: Story = {
   play: async () => {
     const inputImages: SDKImage[] = [
       {
@@ -140,7 +144,7 @@ export const SaveWhitelisedImage_ShouldReportSuccess: Story = {
 
     const imageStudio = new AmplienceImageStudio({
       domain: IMAGE_STUDIO_DOMAIN,
-    }).withEventListener(ImageStudioEventType.ImageSave, (data) => {
+    }).withEventListener(ImageStudioEventType.ImageSave, async (data) => {
       // Aslong as the user doesnt make any changes to the image, expected to receive the same URl back as we submitted to the studio
       const imageData = data as ImageSaveEventData;
       expect(imageData?.image?.url).toBe(
@@ -148,6 +152,10 @@ export const SaveWhitelisedImage_ShouldReportSuccess: Story = {
       );
       expect(imageData?.image?.name).toBe('DO-NOT-CHANGE-ME');
       expect(imageData?.image?.mimeType).toBe('image/jpeg');
+      // delay the response to prove async works
+      console.log('[Storybook] saving image - will take 2 seconds');
+      await sleep(2000);
+      console.log('[Storybook] image saved');
       return SDKEventType.Success;
     });
     await imageStudio.editImages(inputImages);
@@ -166,7 +174,7 @@ export const SaveNonWhitelisedImage_ShouldReportSuccees: Story = {
 
     const imageStudio = new AmplienceImageStudio({
       domain: IMAGE_STUDIO_DOMAIN,
-    }).withEventListener(ImageStudioEventType.ImageSave, (data) => {
+    }).withEventListener(ImageStudioEventType.ImageSave, async (data) => {
       // Aslong as the user doesnt make any changes to the image, expected to receive the same URl back as we submitted to the studio
       const imageData = data as ImageSaveEventData;
       expect(imageData?.image?.url).not.toBe(
@@ -192,7 +200,7 @@ export const SaveImage_ShouldReportFailure: Story = {
 
     const imageStudio = new AmplienceImageStudio({
       domain: IMAGE_STUDIO_DOMAIN,
-    }).withEventListener(ImageStudioEventType.ImageSave, () => {
+    }).withEventListener(ImageStudioEventType.ImageSave, async () => {
       // Intenionally send a failure back to image-studio
       return SDKEventType.Fail;
     });
@@ -212,12 +220,34 @@ export const EventListener_NullResponseShouldTriggerDefaultResponse: Story = {
 
     const imageStudio = new AmplienceImageStudio({
       domain: IMAGE_STUDIO_DOMAIN,
-    }).withEventListener(ImageStudioEventType.ImageSave, () => {
+    }).withEventListener(ImageStudioEventType.ImageSave, async () => {
       return null; // should resolve SDKEventType.Success
     });
     await imageStudio.editImages(inputImages);
   },
 };
+
+export const EventListener_UserThrowsExceptionShouldTriggerDefaultResponse: Story =
+  {
+    play: async () => {
+      const inputImages: SDKImage[] = [
+        {
+          url: 'https://www.catster.com/wp-content/uploads/2023/11/orange-cat-riding-a-roomba-or-robotic-vacuum_Sharomka_Shutterstock.jpg.webp',
+          name: 'DO-NOT-CHANGE-ME',
+          mimeType: 'image/webp',
+        },
+      ];
+
+      const imageStudio = new AmplienceImageStudio({
+        domain: IMAGE_STUDIO_DOMAIN,
+      }).withEventListener(ImageStudioEventType.ImageSave, async () => {
+        throw new Error(
+          'Storybook Testing User Exception Throwing, Should trigger default response to studio',
+        );
+      });
+      await imageStudio.editImages(inputImages);
+    },
+  };
 
 export const LaunchStandalone: Story = {
   play: async () => {

--- a/src/types/EventListenerCallback.ts
+++ b/src/types/EventListenerCallback.ts
@@ -9,7 +9,7 @@ import { SDKEventType } from './SdkEventType';
  */
 export type EventListenerCallback = (
   data: ImageStudioEventData,
-) => SDKEventType | null;
+) => Promise<SDKEventType | null>;
 
 /**
  * Interface for defining SDK response expectations


### PR DESCRIPTION
- Adds async event callback support
- Tidies up some of the 'default' response flows (fixes an issue whereby invalid response from a user callback would not send a default response back to image-studio)
- Exceptions thrown by users callback are now caught and not able to bubble any higher
- Default response is always returned to image-studio unless the user supplied a valid one.
- Adds new stories to cover new behaviour